### PR TITLE
detach() freaks the internal pointer out, so cannot be used within foreach

### DIFF
--- a/src/Adapter/ActiveRecord/UnitOfWork.php
+++ b/src/Adapter/ActiveRecord/UnitOfWork.php
@@ -52,13 +52,15 @@ class UnitOfWork
         foreach ($this->persisted as $persisted) {
             if (!$entity || $entity === $persisted) {
                 $this->getPersisterByEntity($persisted)->save($persisted);
-                $this->persisted->detach($persisted);
 
                 if ($entity) {
-                    break;
+                    $this->persisted->detach($persisted);
+                    return;
                 }
             }
         }
+        
+        $this->persisted->removeAll($this->persisted);
     }
 
     /**


### PR DESCRIPTION
It seems to try to set the internal pointer to `1`

``` php
$spl = new SplObjectStorage();

$n = 4;

for($i=0; $i < $n; $i++) {
  $object = new StdClass;
  $spl->attach($object);
}
foreach($spl as $object) {
    echo $spl->key() . '<br>';
    $spl->detach($object);
}
```

results in

```
0
1
1
```

`n = 3`:

```
0
1
```

`n = 2`:

```
0
```
