### PR TITLE
Ensure entity collection properties have a good default

### DIFF
--- a/src/Adapter/ActiveRecord/Proxy/ProxyFactory.php
+++ b/src/Adapter/ActiveRecord/Proxy/ProxyFactory.php
@@ -97,6 +97,8 @@ class ProxyFactory
      */
     protected function mapRecords(array $records, Collection $collection, MapperInterface $mapper)
     {
+        $collection->clear();
+
         foreach ($records as $record) {
             $entity = $mapper->toEntity($record);
             $this->unitOfWork->persistByTrackingPolicy($entity);


### PR DESCRIPTION
This change ensures the `_elements` property of [ArrayCollection](http://www.doctrine-project.org/api/common/2.3/source-class-Doctrine.Common.Collections.ArrayCollection.html#$_elements) is set to an empty array by default.

Then calls to methods like `contains` don't explode when you're working with an empty collection property.

All credit to @wpillar for the fix.
