### PR TITLE
Ensure EloquentOrm\EntityPersister returns null if no record is found.

### DIFF
--- a/src/Adapter/EloquentOrm/Persister/EntityPersister.php
+++ b/src/Adapter/EloquentOrm/Persister/EntityPersister.php
@@ -38,6 +38,11 @@ class EntityPersister extends AbstractPersister
         }
 
         $record = $query->first();
+        
+        if (! $record) {
+            return null;
+        }
+        
         $mapper = $this->unitOfWork->getMapper($this->entityName);
 
         $entity = $mapper->toEntity($record, $entity);


### PR DESCRIPTION
Without this you get that 'value entity "" is not null' thing. We had to do the same fix for `PropertyTableMapAdapter` way back when.
