### PR TITLE
Fixing class interface generator generating constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "aura/sql": "^2.4",
         "guzzlehttp/guzzle": "^6.1",
         "symfony/yaml": "^2.8",
-        "squizlabs/php_codesniffer": "^2.7"
+        "squizlabs/php_codesniffer": "^2.7,<2.8.1"
     },
     "suggest": {
         "doctrine/orm": "Required when using the DoctrineOrmAdapter",

--- a/src/Generator/AbstractClassGenerator.php
+++ b/src/Generator/AbstractClassGenerator.php
@@ -70,6 +70,11 @@ abstract class AbstractClassGenerator
         $interfaceGenerator = $this->getInterfaceGenerator($interfaceName);
 
         foreach ($classGenerator->getMethods() as $method) {
+            // skip __construct methods which should not be on interfaces
+            if ($method->getName() === '__construct') {
+                continue;
+            }
+
             $interfaceGenerator->addMethodFromGenerator(clone $method);
         }
 

--- a/tests/src/Generator/TestGenerator.php
+++ b/tests/src/Generator/TestGenerator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Graze\Dal\Test\Generator;
+
+use Graze\Dal\Generator\AbstractClassGenerator;
+use Zend\Code\Generator\ClassGenerator;
+
+class TestGenerator extends AbstractClassGenerator
+{
+    /**
+     * @var callable
+     */
+    private $buildClassGeneratorsCallback;
+
+    /**
+     * @return array
+     */
+    protected function buildClassGenerators()
+    {
+        $callable = $this->buildClassGeneratorsCallback;
+        return $callable();
+    }
+
+    /**
+     * @param callable $callback
+     */
+    public function buildClassGeneratorsUsing(callable $callback)
+    {
+        $this->buildClassGeneratorsCallback = $callback;
+    }
+
+    /**
+     * @return array
+     */
+    public function getClassGenerators()
+    {
+        return $this->buildClassGenerators();
+    }
+
+    /**
+     * @param \Zend\Code\Generator\ClassGenerator $classGenerator
+     *
+     * @return \Zend\Code\Generator\InterfaceGenerator
+     */
+    public function buildInterfaceGenerator(ClassGenerator $classGenerator)
+    {
+        return $this->buildInterfaceGeneratorFromClassGenerator($classGenerator);
+    }
+}

--- a/tests/unit/Generator/AbstractClassGeneratorTest.php
+++ b/tests/unit/Generator/AbstractClassGeneratorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Graze\Dal\Test\Unit\Generator;
+
+use Graze\Dal\Test\Generator\TestGenerator;
+use Zend\Code\Generator\ClassGenerator;
+
+class AbstractClassGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Reveals https://github.com/graze/dal/issues/35
+     */
+    public function testInterfaceGeneratedWithoutConstructor()
+    {
+        $testGenerator = new TestGenerator();
+        $testGenerator->buildClassGeneratorsUsing(function () {
+            $classGenerator = new ClassGenerator();
+            $classGenerator->addMethod('__construct');
+
+            return [$classGenerator];
+        });
+
+        $classGenerators = $testGenerator->getClassGenerators();
+        $interfaceGenerator = $testGenerator->buildInterfaceGenerator($classGenerators[0]);
+
+        static::assertFalse($interfaceGenerator->hasMethod('__construct'));
+    }
+}


### PR DESCRIPTION
Fixes #35

- Adds `TestGenerator` to provide some flexibility in testing `AbstractClassGenerator`.
- Changes the `squizlabs/php_codesniffer` dependency to not use `2.8.1` which contains a bug that causes sniffing to fail when it shouldn't.