### PR TITLE
Fix repository generator interfaces not extending ObjectRepository

### DIFF
--- a/src/Generator/RepositoryGenerator.php
+++ b/src/Generator/RepositoryGenerator.php
@@ -50,6 +50,7 @@ class RepositoryGenerator extends AbstractClassGenerator implements GeneratorInt
 
             if ($this->generateInterfaces) {
                 $interfaceGenerator = $this->buildInterfaceGeneratorFromClassGenerator($repository);
+                $interfaceGenerator->setImplementedInterfaces(['\\Doctrine\Common\Persistence\ObjectRepository']);
                 $repositories[$interfaceGenerator->getNamespaceName() . '\\' . $interfaceGenerator->getName()] = $interfaceGenerator;
             }
 

--- a/tests/src/Generator/TestRepositoryGenerator.php
+++ b/tests/src/Generator/TestRepositoryGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Graze\Dal\Test\Generator;
+
+use Graze\Dal\Generator\RepositoryGenerator;
+use Zend\Code\Generator\InterfaceGenerator;
+
+class TestRepositoryGenerator extends RepositoryGenerator
+{
+    /**
+     * @return array
+     */
+    public function getClassGenerators()
+    {
+        return $this->buildClassGenerators();
+    }
+
+    /**
+     * @return array
+     */
+    public function getInterfaceGenerators()
+    {
+        $classGenerators = $this->getClassGenerators();
+        $interfaceGenerators = [];
+
+        foreach ($classGenerators as $classGenerator) {
+            if ($classGenerator instanceof InterfaceGenerator) {
+                $interfaceGenerators[] = $classGenerator;
+            }
+        }
+
+        return $interfaceGenerators;
+    }
+}

--- a/tests/unit/Generator/RepositoryGeneratorTest.php
+++ b/tests/unit/Generator/RepositoryGeneratorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Graze\Dal\Test\Unit\Generator;
+
+use Graze\Dal\Test\Generator\TestRepositoryGenerator;
+use Zend\Code\Generator\InterfaceGenerator;
+
+class RepositoryGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGeneratedInterfaceExtendsObjectRepository()
+    {
+        $repositoryGenerator = new TestRepositoryGenerator([
+            'Foo' => [
+                'repository' => 'FooRepository'
+            ]
+        ], true);
+
+        $interfaceGenerators = $repositoryGenerator->getInterfaceGenerators();
+
+        /** @var InterfaceGenerator $interfaceGenerator */
+        $interfaceGenerator = $interfaceGenerators[0];
+
+        static::assertContains('\Doctrine\Common\Persistence\ObjectRepository', $interfaceGenerator->getImplementedInterfaces());
+    }
+}

--- a/tests/unit/Generator/RepositoryGeneratorTest.php
+++ b/tests/unit/Generator/RepositoryGeneratorTest.php
@@ -7,6 +7,9 @@ use Zend\Code\Generator\InterfaceGenerator;
 
 class RepositoryGeneratorTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Reveals https://github.com/graze/dal/issues/34
+     */
     public function testGeneratedInterfaceExtendsObjectRepository()
     {
         $repositoryGenerator = new TestRepositoryGenerator([


### PR DESCRIPTION
Fixes #34 

- Adds `TestRepositoryGenerator` to make testing `RepositoryGenerator` a little easier.