### PR TITLE
Better dependency testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ php:
   - 7.1
   - hhvm
 
-before_script:
-  - travis_retry composer update --no-interaction
+env:
+  - 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
+  - 'COMPOSER_FLAGS=""'
+
+install:
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpcs -p --warning-severity=0 src/

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "ocramius/proxy-manager": "^1.0",
         "symfony/console": "^2.8",
         "zendframework/zend-hydrator": "^1.0",
-        "zendframework/zend-code": "^2.5"
+        "zendframework/zend-code": "^2.6"
     },
     "require-dev": {
         "adlawson/timezone": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "mockery/mockery": "^0.9.4",
         "phpunit/phpunit": "~4.0",
         "doctrine/orm": "^2.5",
-        "illuminate/database": "5.2.*",
+        "illuminate/database": "^5.2",
         "symfony/var-dumper": "^2.6",
         "aura/sql": "^2.4",
         "guzzlehttp/guzzle": "^6.1",


### PR DESCRIPTION
- Adding `--prefer-lowest` to Travis config to make sure we're testing either end of our dependency versioning.
- Bumping `zendframework/zend-code` dependency to `^2.6`.
- Changing the dev dependency `illuminate/database` to `^5.2` to capture all `5.x` versions.